### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 extension_mod = Extension("slop", sources = ["slop_module.c"], libraries = ['slopy'])
 


### PR DESCRIPTION
`setuptools` is newer, better maintained and recommended by Python docs. Also using `distutils` breaks functionality for some dependency managers (namely `poetry` can't git-install this).

While at it, why not upload to PyPI?